### PR TITLE
Add CI/CD

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,0 +1,30 @@
+name: Latest
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache-
+      - name: Install
+        run: npm i
+      - name: Test
+        run: npm run test --if-present
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Types
+        run: npm run types --if-present

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-npm-cache-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache-
+      - name: Verify
+        run: |
+          npm i
+          npm run preversion
+  npm:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Publish
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > ~/.npmrc
+        npm publish --access public
+  gh:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Publish
+      run: |
+        echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+        ORG="$(echo '${{ github.repository }}' | cut -d'/' -f1)"
+        echo "registry=https://npm.pkg.github.com/$ORG" > .npmrc
+        npm publish

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A web component for creating custom arrow HTML elements.",
   "main": "dist/wc-arrow-node.min.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postversion": "git push --follow-tags"
   },
   "files": [
     "dist/wc-arrow-node.min.js",


### PR DESCRIPTION
This adds everything needed for CI/CD

For example when you use 

```sh
npm version patch
```

It...
- runs lint/test locally if they're present
- automatically increments the version number in package.json
- commits that change
- adds a version tag to that commit
- pushes the commit and version tag
- runs lint/test in a clean env if they're present
- publishes the new version to both NPM and GH Packages

You can check the progress from the `Actions` tab of the repo.

Push access is limited to the main branch so publishing is limited to the project Owner and Org Maintainers.